### PR TITLE
#17 Enforce Tag immutability

### DIFF
--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -114,7 +114,7 @@ public static class TagSerializer
                         items[index] = temporary;
                     }
 
-                    tag = new ListTag(items, name);
+                    tag = new ListTag([.. items.AsSpan()], name);
 
                     return true;
                 }
@@ -153,7 +153,7 @@ public static class TagSerializer
                         return false;
                     }
 
-                    tag = new CompoundTag(items[..index], name);
+                    tag = new CompoundTag([.. items.AsSpan(0, index)], name);
 
                     return true;
                 }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Raspite.Tags;
 
-public sealed class CompoundTag : Tag<Tag[]>
+public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
 {
     public override byte Identifier => Compound;
 
@@ -16,7 +16,7 @@ public sealed class CompoundTag : Tag<Tag[]>
 
     private readonly FrozenDictionary<string, Tag> cache;
 
-    public CompoundTag(Tag[] value, string name = "") : base(value, name)
+    public CompoundTag(ImmutableArray<Tag> value, string name = "") : base(value, name)
     {
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -1,6 +1,8 @@
-﻿namespace Raspite.Tags;
+﻿using System.Collections.Immutable;
 
-public sealed class ListTag(Tag[] value, string name = "") : Tag<Tag[]>(value, name)
+namespace Raspite.Tags;
+
+public sealed class ListTag(ImmutableArray<Tag> value, string name = "") : Tag<ImmutableArray<Tag>>(value, name)
 {
     public override byte Identifier => List;
 }


### PR DESCRIPTION
Fixes #17 

- Replace Tag[] with `ImmutableArray<Tag>`
- Use AsSpan with collection expressions as the IL results in more optimized code, without LINQ