### PR TITLE
#19 Remove hard-coded compound tag maximum of 512

### DIFF
--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -92,12 +92,8 @@ public static class TagSerializer
 
                 case Tag.List when reader.TryReadListTag(out var identifier, out var length, out var name):
                 {
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(length, maximumChildren);
                     maximumDepth--;
-
-                    if (length > maximumChildren)
-                    {
-                        throw new ArgumentException($"ListTag exceeds maximum of {maximumChildren} children.");
-                    }
 
                     if (identifier is Tag.End || length < 1)
                     {
@@ -159,11 +155,7 @@ public static class TagSerializer
                                 return false;
                             }
 
-                            if (index >= maximumChildren)
-                            {
-                                throw new ArgumentException($"CompoundTag exceeds maximum of {maximumChildren} children.");
-                            }
-
+                            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, maximumChildren);
                             items[index++] = temporary;
                         }
 
@@ -252,12 +244,8 @@ public static class TagSerializer
 
                 case ListTag current:
                 {
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(current.Value.Length, maximumChildren);
                     maximumDepth--;
-
-                    if (current.Value.Length > maximumChildren)
-                    {
-                        throw new ArgumentException($"ListTag with {current.Value.Length} children exceeds maximum of {maximumChildren}.");
-                    }
 
                     if (current.Value.Length < 1)
                     {
@@ -278,12 +266,8 @@ public static class TagSerializer
 
                 case CompoundTag current:
                 {
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(current.Value.Length, maximumChildren);
                     maximumDepth--;
-
-                    if (current.Value.Length > maximumChildren)
-                    {
-                        throw new ArgumentException($"CompoundTag with {current.Value.Length} children exceeds maximum of {maximumChildren}.");
-                    }
 
                     writer.WriteCompoundTag(current.Name);
 

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -50,11 +50,11 @@ public static class TagSerializer
         tag = EndTag.Instance;
 
         var reader = new TagReader(buffer, options.Value.LittleEndian, options.Value.Network);
-        var success = reader.TryPeek(out var parent) && TryInstantiate(ref reader, out tag, parent, options.Value.MaximumDepth);
+        var success = reader.TryPeek(out var parent) && TryInstantiate(ref reader, out tag, parent, options.Value.MaximumDepth, options.Value.MaximumChildren);
 
         return success;
 
-        static bool TryInstantiate(ref TagReader reader, out Tag tag, byte parent, int maximumDepth)
+        static bool TryInstantiate(ref TagReader reader, out Tag tag, byte parent, int maximumDepth, int maximumChildren)
         {
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
 
@@ -94,27 +94,39 @@ public static class TagSerializer
                 {
                     maximumDepth--;
 
+                    if (length > maximumChildren)
+                    {
+                        throw new ArgumentException($"ListTag exceeds maximum of {maximumChildren} children.");
+                    }
+
                     if (identifier is Tag.End || length < 1)
                     {
                         tag = new ListTag([], name);
                         return true;
                     }
 
-                    var items = new Tag[length];
+                    var items = ArrayPool<Tag>.Shared.Rent(length);
 
-                    for (var index = 0; index < length; index++)
+                    try
                     {
-                        reader.Nameless = true;
-
-                        if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth))
+                        for (var index = 0; index < length; index++)
                         {
-                            return false;
+                            reader.Nameless = true;
+
+                            if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth, maximumChildren))
+                            {
+                                return false;
+                            }
+
+                            items[index] = temporary;
                         }
 
-                        items[index] = temporary;
+                        tag = new ListTag([.. items.AsSpan(0, length)], name);
                     }
-
-                    tag = new ListTag([.. items.AsSpan()], name);
+                    finally
+                    {
+                        ArrayPool<Tag>.Shared.Return(items, clearArray: true);
+                    }
 
                     return true;
                 }
@@ -123,37 +135,49 @@ public static class TagSerializer
                 {
                     maximumDepth--;
 
-                    var items = new Tag[512];
+                    var items = ArrayPool<Tag>.Shared.Rent(maximumChildren);
                     var index = 0;
 
-                    while (true)
+                    try
                     {
-                        if (!reader.TryPeek(out var identifier))
+                        while (true)
+                        {
+                            if (!reader.TryPeek(out var identifier))
+                            {
+                                return false;
+                            }
+
+                            if (identifier is Tag.End)
+                            {
+                                break;
+                            }
+
+                            reader.Nameless = false;
+
+                            if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth, maximumChildren))
+                            {
+                                return false;
+                            }
+
+                            if (index >= maximumChildren)
+                            {
+                                throw new ArgumentException($"CompoundTag exceeds maximum of {maximumChildren} children.");
+                            }
+
+                            items[index++] = temporary;
+                        }
+
+                        if (!reader.TryReadEndTag())
                         {
                             return false;
                         }
 
-                        if (identifier is Tag.End)
-                        {
-                            break;
-                        }
-
-                        reader.Nameless = false;
-
-                        if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth))
-                        {
-                            return false;
-                        }
-
-                        items[index++] = temporary;
+                        tag = new CompoundTag([.. items.AsSpan(0, index)], name);
                     }
-
-                    if (!reader.TryReadEndTag())
+                    finally
                     {
-                        return false;
+                        ArrayPool<Tag>.Shared.Return(items, clearArray: true);
                     }
-
-                    tag = new CompoundTag([.. items.AsSpan(0, index)], name);
 
                     return true;
                 }
@@ -188,11 +212,11 @@ public static class TagSerializer
 
         var writer = new TagWriter(buffer, options.Value.LittleEndian, options.Value.Network);
 
-        Write(ref writer, tag, options.Value.MaximumDepth);
+        Write(ref writer, tag, options.Value.MaximumDepth, options.Value.MaximumChildren);
 
         return;
 
-        static void Write(ref TagWriter writer, Tag tag, int maximumDepth)
+        static void Write(ref TagWriter writer, Tag tag, int maximumDepth, int maximumChildren)
         {
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
 
@@ -230,6 +254,11 @@ public static class TagSerializer
                 {
                     maximumDepth--;
 
+                    if (current.Value.Length > maximumChildren)
+                    {
+                        throw new ArgumentException($"ListTag with {current.Value.Length} children exceeds maximum of {maximumChildren}.");
+                    }
+
                     if (current.Value.Length < 1)
                     {
                         writer.WriteListTag(Tag.End, 0, current.Name);
@@ -241,7 +270,7 @@ public static class TagSerializer
                     foreach (var item in current.Value)
                     {
                         writer.Nameless = true;
-                        Write(ref writer, item, maximumDepth);
+                        Write(ref writer, item, maximumDepth, maximumChildren);
                     }
 
                     break;
@@ -251,12 +280,17 @@ public static class TagSerializer
                 {
                     maximumDepth--;
 
+                    if (current.Value.Length > maximumChildren)
+                    {
+                        throw new ArgumentException($"CompoundTag with {current.Value.Length} children exceeds maximum of {maximumChildren}.");
+                    }
+
                     writer.WriteCompoundTag(current.Name);
 
                     foreach (var item in current.Value)
                     {
                         writer.Nameless = false;
-                        Write(ref writer, item, maximumDepth);
+                        Write(ref writer, item, maximumDepth, maximumChildren);
                     }
 
                     writer.WriteEndTag();

--- a/Raspite/TagSerializerOptions.cs
+++ b/Raspite/TagSerializerOptions.cs
@@ -19,4 +19,9 @@ public readonly record struct TagSerializerOptions()
     /// The maximum allowed nest depth.
     /// </summary>
     public int MaximumDepth { get; init; } = 512;
+
+    /// <summary>
+    /// The maximum allowed number of children in a list or compound tag.
+    /// </summary>
+    public int MaximumChildren { get; init; } = 512;
 }


### PR DESCRIPTION
- Outsource to property inside TagSerializerOptions
- Use ArrayPools instead of fixed size arrays
- Apply safety checks and ArrayPool change to ListTags as well