### PR TITLE
Add generic API to ListTag

### DIFF
--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -5,4 +5,18 @@ namespace Raspite.Tags;
 public sealed class ListTag(ImmutableArray<Tag> value, string name = "") : Tag<ImmutableArray<Tag>>(value, name)
 {
     public override byte Identifier => List;
+
+    public Tag this[int index] => Value[index];
+
+    public int Length => Value.Length;
+
+    public TTag Get<TTag>(int index) where TTag : Tag
+    {
+        return (TTag) Value[index];
+    }
+
+    public T GetValue<T>(int index)
+    {
+        return ((Tag<T>) Value[index]).Value;
+    }
 }


### PR DESCRIPTION
Closes #22

I did not add `GetOrDefault` and `TryGet` because I am not sure how much sense this would make for an indexed list. And obviously no `Contains(int index)` method either.

@TheVeryStarlk is this fine or should some of these 3 be supported?