### PR TITLE
Extend CompoundTag and ListTag API to accept ranges of values

### DIFF
--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -145,6 +145,126 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
+    public CompoundTagBuilder AddByteList(ReadOnlySpan<byte?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddByteList(ReadOnlySpan<byte> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddShortList(ReadOnlySpan<short?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddShortList(ReadOnlySpan<short> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddLongList(ReadOnlySpan<long?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddLongList(ReadOnlySpan<long> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddFloatList(ReadOnlySpan<float?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddFloatList(ReadOnlySpan<float> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddStringList(ReadOnlySpan<string?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<StringTag>.Create(name).AddStringRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddCompoundList(ReadOnlySpan<CompoundTag?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<CompoundTag>.Create(name).AddCompoundRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddListList(ReadOnlySpan<ListTag?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<ListTag>.Create(name).AddListRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddBytesList(ReadOnlySpan<byte[]?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<BytesTag>.Create(name).AddBytesRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddIntegersList(ReadOnlySpan<int[]?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<IntegersTag>.Create(name).AddIntegersRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder AddLongsList(ReadOnlySpan<long[]?> values, string name = "")
+    {
+        tags.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
+        return this;
+    }
+
     public CompoundTag Build()
     {
         return new CompoundTag([.. tags], parentName);

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -158,3 +158,206 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 }
+
+public static class ListTagBuilderRangeExtensions
+{
+    public static ListTagBuilder<ByteTag> AddByteRange(this ListTagBuilder<ByteTag> builder, params ReadOnlySpan<byte?> range)
+    {
+        foreach (byte? value in range)
+        {
+            builder.AddByte(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ByteTag> AddByteRange(this ListTagBuilder<ByteTag> builder, params ReadOnlySpan<byte> range)
+    {
+        foreach (byte value in range)
+        {
+            builder.AddByte(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ByteTag> AddBooleanRange(this ListTagBuilder<ByteTag> builder, params ReadOnlySpan<bool?> range)
+    {
+        foreach (bool? value in range)
+        {
+            builder.AddBoolean(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ByteTag> AddBooleanRange(this ListTagBuilder<ByteTag> builder, params ReadOnlySpan<bool> range)
+    {
+        foreach (bool value in range)
+        {
+            builder.AddBoolean(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ShortTag> AddShortRange(this ListTagBuilder<ShortTag> builder, params ReadOnlySpan<short?> range)
+    {
+        foreach (short? value in range)
+        {
+            builder.AddShort(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ShortTag> AddShortRange(this ListTagBuilder<ShortTag> builder, params ReadOnlySpan<short> range)
+    {
+        foreach (short value in range)
+        {
+            builder.AddShort(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<IntegerTag> AddIntegerRange(this ListTagBuilder<IntegerTag> builder, params ReadOnlySpan<int?> range)
+    {
+        foreach (int? value in range)
+        {
+            builder.AddInteger(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<IntegerTag> AddIntegerRange(this ListTagBuilder<IntegerTag> builder, params ReadOnlySpan<int> range)
+    {
+        foreach (int value in range)
+        {
+            builder.AddInteger(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<LongTag> AddLongRange(this ListTagBuilder<LongTag> builder, params ReadOnlySpan<long?> range)
+    {
+        foreach (long? value in range)
+        {
+            builder.AddLong(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<LongTag> AddLongRange(this ListTagBuilder<LongTag> builder, params ReadOnlySpan<long> range)
+    {
+        foreach (long value in range)
+        {
+            builder.AddLong(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<FloatTag> AddFloatRange(this ListTagBuilder<FloatTag> builder, params ReadOnlySpan<float?> range)
+    {
+        foreach (float? value in range)
+        {
+            builder.AddFloat(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<FloatTag> AddFloatRange(this ListTagBuilder<FloatTag> builder, params ReadOnlySpan<float> range)
+    {
+        foreach (float value in range)
+        {
+            builder.AddFloat(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<DoubleTag> AddDoubleRange(this ListTagBuilder<DoubleTag> builder, params ReadOnlySpan<double?> range)
+    {
+        foreach (double? value in range)
+        {
+            builder.AddDouble(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<DoubleTag> AddDoubleRange(this ListTagBuilder<DoubleTag> builder, params ReadOnlySpan<double> range)
+    {
+        foreach (double value in range)
+        {
+            builder.AddDouble(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<StringTag> AddStringRange(this ListTagBuilder<StringTag> builder, params ReadOnlySpan<string?> range)
+    {
+        foreach (string? value in range)
+        {
+            builder.AddString(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<CompoundTag> AddCompoundRange(this ListTagBuilder<CompoundTag> builder, params ReadOnlySpan<CompoundTag?> range)
+    {
+        foreach (CompoundTag? value in range)
+        {
+            builder.AddCompound(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<ListTag> AddListRange(this ListTagBuilder<ListTag> builder, params ReadOnlySpan<ListTag?> range)
+    {
+        foreach (ListTag? value in range)
+        {
+            builder.AddList(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<BytesTag> AddBytesRange(this ListTagBuilder<BytesTag> builder, params ReadOnlySpan<byte[]?> range)
+    {
+        foreach (byte[]? value in range)
+        {
+            builder.AddBytes(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<IntegersTag> AddIntegersRange(this ListTagBuilder<IntegersTag> builder, params ReadOnlySpan<int[]?> range)
+    {
+        foreach (int[]? value in range)
+        {
+            builder.AddIntegers(value);
+        }
+
+        return builder;
+    }
+
+    public static ListTagBuilder<LongsTag> AddLongsRange(this ListTagBuilder<LongsTag> builder, params ReadOnlySpan<long[]?> range)
+    {
+        foreach (long[]? value in range)
+        {
+            builder.AddLongs(value);
+        }
+
+        return builder;
+    }
+}

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -20,9 +20,9 @@ public sealed class ListTagBuilder<TTag> where TTag : Tag
         tags.Add(tag);
     }
 
-    public ListTag<TTag> Build()
+    public ListTag Build()
     {
-        return new ListTag<TTag>([.. tags], parentName);
+        return new ListTag([.. tags], parentName);
     }
 }
 
@@ -118,7 +118,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : Tag
+    public static ListTagBuilder<ListTag> AddList(this ListTagBuilder<ListTag> builder, ListTag? value)
     {
         if (value is not null)
         {

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -20,9 +20,9 @@ public sealed class ListTagBuilder<TTag> where TTag : Tag
         tags.Add(tag);
     }
 
-    public ListTag Build()
+    public ListTag<TTag> Build()
     {
-        return new ListTag([.. tags], parentName);
+        return new ListTag<TTag>([.. tags], parentName);
     }
 }
 
@@ -118,7 +118,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag> AddList(this ListTagBuilder<ListTag> builder, ListTag? value)
+    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : Tag
     {
         if (value is not null)
         {

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -9,4 +9,14 @@ public sealed class ListTag(ImmutableArray<Tag> value, string name = "") : Tag<I
     public Tag this[int index] => Value[index];
 
     public int Length => Value.Length;
+
+    public TTag Get<TTag>(int index) where TTag : Tag
+    {
+        return (TTag) Value[index];
+    }
+
+    public T GetValue<T>(int index)
+    {
+        return ((Tag<T>) Value[index]).Value;
+    }
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -2,21 +2,11 @@
 
 namespace Raspite.Tags;
 
-public sealed class ListTag(ImmutableArray<Tag> value, string name = "") : Tag<ImmutableArray<Tag>>(value, name)
+public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name) where TTag : Tag
 {
     public override byte Identifier => List;
 
-    public Tag this[int index] => Value[index];
+    public TTag this[int index] => Value[index];
 
     public int Length => Value.Length;
-
-    public TTag Get<TTag>(int index) where TTag : Tag
-    {
-        return (TTag) Value[index];
-    }
-
-    public T GetValue<T>(int index)
-    {
-        return ((Tag<T>) Value[index]).Value;
-    }
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -2,11 +2,11 @@
 
 namespace Raspite.Tags;
 
-public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name) where TTag : Tag
+public sealed class ListTag(ImmutableArray<Tag> value, string name = "") : Tag<ImmutableArray<Tag>>(value, name)
 {
     public override byte Identifier => List;
 
-    public TTag this[int index] => Value[index];
+    public Tag this[int index] => Value[index];
 
     public int Length => Value.Length;
 }


### PR DESCRIPTION
This should fix #29

I know it's a low of clutter but I think it may still be the cleanest solution. Another way would be to outsource the new methods in `CompoundTag` to extension methods, or putting them inside a `#region` block to avoid bloat. But let me know what you think!