### PR TITLE
Allow deleting tags from CompoundTags

### DIFF
--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -2,17 +2,18 @@ namespace Raspite.Tags.Building;
 
 public sealed class CompoundTagBuilder
 {
-    private readonly List<Tag> tags = [];
+    private readonly List<Tag> tags;
     private readonly string parentName;
 
-    private CompoundTagBuilder(string tag)
+    internal CompoundTagBuilder(List<Tag> initialTags, string name)
     {
-        parentName = tag;
+        tags = initialTags;
+        parentName = name;
     }
 
     public static CompoundTagBuilder Create(string name = "")
     {
-        return new CompoundTagBuilder(name);
+        return new CompoundTagBuilder([], name);
     }
 
     public CompoundTagBuilder AddByte(byte? value, string name = "")
@@ -262,6 +263,18 @@ public sealed class CompoundTagBuilder
     public CompoundTagBuilder AddLongsList(ReadOnlySpan<long[]?> values, string name = "")
     {
         tags.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
+        return this;
+    }
+
+    public CompoundTagBuilder Remove(string name)
+    {
+        tags.RemoveAll(tag => tag.Name == name);
+        return this;
+    }
+
+    public CompoundTagBuilder RemoveAll(Predicate<Tag> predicate)
+    {
+        tags.RemoveAll(predicate);
         return this;
     }
 

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -2,22 +2,35 @@ namespace Raspite.Tags.Building;
 
 public sealed class ListTagBuilder<TTag> where TTag : Tag
 {
-    private readonly List<TTag> tags = [];
+    private readonly List<TTag> tags;
     private readonly string parentName;
 
-    private ListTagBuilder(string name)
+    private ListTagBuilder(List<TTag> initalTags, string name)
     {
+        tags = initalTags;
         parentName = name;
     }
 
     public static ListTagBuilder<TTag> Create(string name = "")
     {
-        return new ListTagBuilder<TTag>(name);
+        return new ListTagBuilder<TTag>([], name);
     }
 
     internal void Add(TTag tag)
     {
         tags.Add(tag);
+    }
+
+    public ListTagBuilder<TTag> Remove(string name)
+    {
+        tags.RemoveAll(tag => tag.Name == name);
+        return this;
+    }
+
+    public ListTagBuilder<TTag> RemoveAll(Predicate<TTag> predicate)
+    {
+        tags.RemoveAll(predicate);
+        return this;
     }
 
     public ListTag Build()

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -5,7 +5,7 @@ public sealed class ListTagBuilder<TTag> where TTag : Tag
     private readonly List<TTag> tags;
     private readonly string parentName;
 
-    private ListTagBuilder(List<TTag> initalTags, string name)
+    internal ListTagBuilder(List<TTag> initalTags, string name)
     {
         tags = initalTags;
         parentName = name;

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -2,6 +2,8 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 
+using Raspite.Tags.Building;
+
 namespace Raspite.Tags;
 
 public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
@@ -73,5 +75,20 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
     public bool ContainsKey(string name)
     {
         return cache.ContainsKey(name);
+    }
+
+    /// <summary>
+    /// Converts this tag to a builder containing all the values this tag contained.
+    /// It is the inverse operation of <code>CompoundTagBuilder.Build()</code>
+    /// </summary>
+    /// <param name="name">
+    /// The name of the tag about to be built.
+    /// Can be used for renaming it.
+    /// <code>null</code> to leave the name as it was.
+    /// </param>
+    /// <returns></returns>
+    public CompoundTagBuilder ToBuilder(string? name = null)
+    {
+        return new CompoundTagBuilder([.. Value], name ?? Name);
     }
 }


### PR DESCRIPTION
This fixes the first half of #28.

This PR also adds the necessary functionality to `ListTagBuilder`, but no method of convertig a `ListTag` to a `ListTagBuilder<TTag>` yet, since that requires `ListTag` itself to be generic. These changes will come with the PR fixing #27.