### PR TITLE
Make ListTags generic and convertible to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var success = TagSerializer.TryParse<CompoundTag>(source, out var tag);
 However, for streaming scenarios it can be easily used like in the example below.
 
 ```cs
-async ValueTask<Tag?> ReadTagAsync(PipeReader reader, CancellationToken cancellationToken)
+async ValueTask<ITag?> ReadTagAsync(PipeReader reader, CancellationToken cancellationToken)
 {
     while (true)
     {

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -201,7 +201,7 @@ public static class TagSerializer
         }
     }
     
-    private static bool TryReadGenericList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : Tag
+    private static bool TryReadGenericList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : ITag
     {
         var items = ArrayPool<TTag>.Shared.Rent(length);
 

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -120,18 +120,18 @@ public static class TagSerializer
 
                 return identifier switch
                 {
-                    Tag.Byte => TryReadGenericList<ByteTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Short => TryReadGenericList<ShortTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Integer => TryReadGenericList<IntegerTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Long => TryReadGenericList<LongTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Float => TryReadGenericList<FloatTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Double => TryReadGenericList<DoubleTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Bytes => TryReadGenericList<BytesTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.String => TryReadGenericList<StringTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.List => TryReadGenericList<Tag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag), // TODO: Rethink usage of Tag
-                    Tag.Compound => TryReadGenericList<CompoundTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Integers => TryReadGenericList<IntegersTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
-                    Tag.Longs => TryReadGenericList<LongsTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Byte => TryReadList<ByteTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Short => TryReadList<ShortTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Integer => TryReadList<IntegerTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Long => TryReadList<LongTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Float => TryReadList<FloatTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Double => TryReadList<DoubleTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Bytes => TryReadList<BytesTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.String => TryReadList<StringTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.List => TryReadList<IListTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Compound => TryReadList<CompoundTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Integers => TryReadList<IntegersTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Longs => TryReadList<LongsTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
                     _ => false
                 };
             }
@@ -201,7 +201,7 @@ public static class TagSerializer
         }
     }
     
-    private static bool TryReadGenericList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : ITag
+    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : ITag
     {
         var items = ArrayPool<TTag>.Shared.Rent(length);
 
@@ -221,12 +221,13 @@ public static class TagSerializer
             }
 
             tag = new ListTag<TTag>([.. items.AsSpan(0, length)], name);
-            return true;
         }
         finally
         {
             ArrayPool<TTag>.Shared.Return(items, clearArray: true);
         }
+
+        return true;
     }
 
     private static void Write(ref TagWriter writer, Tag tag, int maximumDepth, int maximumChildren)

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -270,7 +270,13 @@ public static class TagSerializer
 
                 maximumDepth--;
 
-                writer.WriteListTag(current.ElementIdentifier, current.Length, current.Name);
+                if (current.Length < 1)
+                {
+                    writer.WriteListTag(Tag.End, 0, current.Name);
+                    return;
+                }
+
+                writer.WriteListTag(current.Elements[0].Identifier, current.Length, current.Name);
 
                 foreach (var item in current.Elements)
                 {

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -13,7 +13,7 @@ public static class TagSerializer
     /// Attempts to parse the <see cref="ReadOnlySpan{T}"/> as a <see cref="TTag"/>.
     /// </summary>
     /// <param name="buffer">The <see cref="ReadOnlySpan{T}"/> to parse.</param>
-    /// <param name="tag">The parsed <see cref="Tag"/>.</param>
+    /// <param name="tag">The parsed <see cref="ITag"/>.</param>
     /// <param name="options">The <see cref="TagSerializerOptions"/> to use.</param>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
     /// <typeparam name="TTag">The expected <see cref="TTag"/> type.</typeparam>
@@ -37,13 +37,13 @@ public static class TagSerializer
     }
 
     /// <summary>
-    /// Attempts to parse the <see cref="ReadOnlySpan{T}"/> as a <see cref="Tag"/>.
+    /// Attempts to parse the <see cref="ReadOnlySpan{T}"/> as a <see cref="ITag"/>.
     /// </summary>
     /// <param name="buffer">The <see cref="ReadOnlySpan{T}"/> to parse.</param>
-    /// <param name="tag">The parsed <see cref="Tag"/>.</param>
+    /// <param name="tag">The parsed <see cref="ITag"/>.</param>
     /// <param name="options">The <see cref="TagSerializerOptions"/> to use.</param>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
-    public static bool TryParse(ReadOnlySpan<byte> buffer, out Tag tag, TagSerializerOptions? options = null)
+    public static bool TryParse(ReadOnlySpan<byte> buffer, out ITag tag, TagSerializerOptions? options = null)
     {
         options ??= new TagSerializerOptions();
 
@@ -56,12 +56,12 @@ public static class TagSerializer
     }
 
     /// <summary>
-    /// Serializes the <see cref="Tag"/> to a <see cref="IBufferWriter{T}"/>.
+    /// Serializes the <see cref="ITag"/> to a <see cref="IBufferWriter{T}"/>.
     /// </summary>
     /// <param name="buffer">The <see cref="IBufferWriter{T}"/> to serialize to.</param>
-    /// <param name="tag">The <see cref="Tag"/> to serialize.</param>
+    /// <param name="tag">The <see cref="ITag"/> to serialize.</param>
     /// <param name="options">The <see cref="TagSerializerOptions"/> to use.</param>
-    public static void Serialize(IBufferWriter<byte> buffer, Tag tag, TagSerializerOptions? options = null)
+    public static void Serialize(IBufferWriter<byte> buffer, ITag tag, TagSerializerOptions? options = null)
     {
         options ??= new TagSerializerOptions();
 
@@ -70,7 +70,7 @@ public static class TagSerializer
         Write(ref writer, tag, options.Value.MaximumDepth, options.Value.MaximumChildren);
     }
 
-    private static bool TryInstantiate(ref TagReader reader, out Tag tag, byte parent, int maximumDepth, int maximumChildren)
+    private static bool TryInstantiate(ref TagReader reader, out ITag tag, byte parent, int maximumDepth, int maximumChildren)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
 
@@ -140,7 +140,7 @@ public static class TagSerializer
             {
                 maximumDepth--;
 
-                var items = ArrayPool<Tag>.Shared.Rent(maximumChildren);
+                var items = ArrayPool<ITag>.Shared.Rent(maximumChildren);
                 var index = 0;
 
                 try
@@ -178,7 +178,7 @@ public static class TagSerializer
                 }
                 finally
                 {
-                    ArrayPool<Tag>.Shared.Return(items, clearArray: true);
+                    ArrayPool<ITag>.Shared.Return(items, clearArray: true);
                 }
 
                 return true;
@@ -201,7 +201,7 @@ public static class TagSerializer
         }
     }
     
-    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : ITag
+    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out ITag tag) where TTag : ITag
     {
         var items = ArrayPool<TTag>.Shared.Rent(length);
 
@@ -230,7 +230,7 @@ public static class TagSerializer
         return true;
     }
 
-    private static void Write(ref TagWriter writer, Tag tag, int maximumDepth, int maximumChildren)
+    private static void Write(ref TagWriter writer, ITag tag, int maximumDepth, int maximumChildren)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
 

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -276,9 +276,9 @@ public static class TagSerializer
                     return;
                 }
 
-                writer.WriteListTag(current.Elements[0].Identifier, current.Length, current.Name);
+                writer.WriteListTag(current.RawTags[0].Identifier, current.Length, current.Name);
 
-                foreach (var item in current.Elements)
+                foreach (var item in current.RawTags)
                 {
                     writer.Nameless = true;
                     Write(ref writer, item, maximumDepth, maximumChildren);

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -114,34 +114,26 @@ public static class TagSerializer
 
                 if (identifier is Tag.End || length < 1)
                 {
-                    tag = new ListTag([], name);
+                    tag = new ListTag<EndTag>([], name);
                     return true;
                 }
 
-                var items = ArrayPool<Tag>.Shared.Rent(length);
-
-                try
+                return identifier switch
                 {
-                    for (var index = 0; index < length; index++)
-                    {
-                        reader.Nameless = true;
-
-                        if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth, maximumChildren))
-                        {
-                            return false;
-                        }
-
-                        items[index] = temporary;
-                    }
-
-                    tag = new ListTag([.. items.AsSpan(0, length)], name);
-                }
-                finally
-                {
-                    ArrayPool<Tag>.Shared.Return(items, clearArray: true);
-                }
-
-                return true;
+                    Tag.Byte => TryReadGenericList<ByteTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Short => TryReadGenericList<ShortTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Integer => TryReadGenericList<IntegerTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Long => TryReadGenericList<LongTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Float => TryReadGenericList<FloatTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Double => TryReadGenericList<DoubleTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Bytes => TryReadGenericList<BytesTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.String => TryReadGenericList<StringTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.List => TryReadGenericList<Tag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag), // TODO: Rethink usage of Tag
+                    Tag.Compound => TryReadGenericList<CompoundTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Integers => TryReadGenericList<IntegersTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    Tag.Longs => TryReadGenericList<LongsTag>(ref reader, identifier, length, name, maximumDepth, maximumChildren, out tag),
+                    _ => false
+                };
             }
 
             case Tag.Compound when reader.TryReadCompoundTag(out var name):
@@ -208,6 +200,34 @@ public static class TagSerializer
                 return false;
         }
     }
+    
+    private static bool TryReadGenericList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out Tag tag) where TTag : Tag
+    {
+        var items = ArrayPool<TTag>.Shared.Rent(length);
+
+        try
+        {
+            for (var index = 0; index < length; index++)
+            {
+                reader.Nameless = true;
+
+                if (!TryInstantiate(ref reader, out var temporary, identifier, maximumDepth, maximumChildren) || temporary is not TTag typedTag)
+                {
+                    tag = EndTag.Instance;
+                    return false;
+                }
+
+                items[index] = typedTag;
+            }
+
+            tag = new ListTag<TTag>([.. items.AsSpan(0, length)], name);
+            return true;
+        }
+        finally
+        {
+            ArrayPool<TTag>.Shared.Return(items, clearArray: true);
+        }
+    }
 
     private static void Write(ref TagWriter writer, Tag tag, int maximumDepth, int maximumChildren)
     {
@@ -243,21 +263,15 @@ public static class TagSerializer
                 writer.WriteStringTag(current.Value, current.Name);
                 break;
 
-            case ListTag current:
+            case IListTag current:
             {
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(current.Value.Length, maximumChildren);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(current.Length, maximumChildren);
 
                 maximumDepth--;
 
-                if (current.Value.Length < 1)
-                {
-                    writer.WriteListTag(Tag.End, 0, current.Name);
-                    return;
-                }
+                writer.WriteListTag(current.ElementIdentifier, current.Length, current.Name);
 
-                writer.WriteListTag(current.Value[0].Identifier, current.Value.Length, current.Name);
-
-                foreach (var item in current.Value)
+                foreach (var item in current.Elements)
                 {
                     writer.Nameless = true;
                     Write(ref writer, item, maximumDepth, maximumChildren);

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -16,7 +16,7 @@ public sealed class CompoundTagBuilder
         return new CompoundTagBuilder([], name);
     }
 
-    internal void Add(ITag tag)
+    public void Add(ITag tag)
     {
         tags.Add(tag);
     }

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -16,254 +16,9 @@ public sealed class CompoundTagBuilder
         return new CompoundTagBuilder([], name);
     }
 
-    public CompoundTagBuilder AddByte(byte? value, string name = "")
+    internal void Add(Tag tag)
     {
-        if (value.HasValue)
-        {
-            tags.Add(new ByteTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddBoolean(bool? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new ByteTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddShort(short? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new ShortTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddInteger(int? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new IntegerTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddLong(long? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new LongTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddFloat(float? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new FloatTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddDouble(double? value, string name = "")
-    {
-        if (value.HasValue)
-        {
-            tags.Add(new DoubleTag(value.Value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddString(string? value, string name = "")
-    {
-        if (value is not null)
-        {
-            tags.Add(new StringTag(value, name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : ITag
-    {
-        if (value is not null)
-        {
-            tags.Add(value);
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddCompound(CompoundTag? value, string name = "")
-    {
-        if (value is not null)
-        {
-            tags.Add(value);
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddBytes(byte[]? value, string name = "")
-    {
-        if (value is not null)
-        {
-            tags.Add(new BytesTag([.. value], name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddIntegers(int[]? value, string name = "")
-    {
-        if (value is not null)
-        {
-            tags.Add(new IntegersTag([.. value], name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddLongs(long[]? value, string name = "")
-    {
-        if (value is not null)
-        {
-            tags.Add(new LongsTag([.. value], name));
-        }
-
-        return this;
-    }
-
-    public CompoundTagBuilder AddByteList(ReadOnlySpan<byte?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddByteList(ReadOnlySpan<byte> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddShortList(ReadOnlySpan<short?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddShortList(ReadOnlySpan<short> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddLongList(ReadOnlySpan<long?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddLongList(ReadOnlySpan<long> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddFloatList(ReadOnlySpan<float?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddFloatList(ReadOnlySpan<float> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddStringList(ReadOnlySpan<string?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<StringTag>.Create(name).AddStringRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddCompoundList(ReadOnlySpan<CompoundTag?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<CompoundTag>.Create(name).AddCompoundRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : ITag
-    {
-        tags.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddBytesList(ReadOnlySpan<byte[]?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<BytesTag>.Create(name).AddBytesRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddIntegersList(ReadOnlySpan<int[]?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<IntegersTag>.Create(name).AddIntegersRange(values).Build());
-        return this;
-    }
-
-    public CompoundTagBuilder AddLongsList(ReadOnlySpan<long[]?> values, string name = "")
-    {
-        tags.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
-        return this;
+        tags.Add(tag);
     }
 
     public CompoundTagBuilder Remove(string name)
@@ -281,5 +36,267 @@ public sealed class CompoundTagBuilder
     public CompoundTag Build()
     {
         return new CompoundTag([.. tags], parentName);
+    }
+}
+
+public static class CompoundTagBuilderExtensions
+{
+    extension(CompoundTagBuilder builder)
+    {
+        public CompoundTagBuilder AddByte(byte? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new ByteTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddBoolean(bool? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new ByteTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddShort(short? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new ShortTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddInteger(int? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new IntegerTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddLong(long? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new LongTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddFloat(float? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new FloatTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddDouble(double? value, string name = "")
+        {
+            if (value.HasValue)
+            {
+                builder.Add(new DoubleTag(value.Value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddString(string? value, string name = "")
+        {
+            if (value is not null)
+            {
+                builder.Add(new StringTag(value, name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : ITag
+        {
+            if (value is not null)
+            {
+                builder.Add(value);
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddCompound(CompoundTag? value, string name = "")
+        {
+            if (value is not null)
+            {
+                builder.Add(value);
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddBytes(byte[]? value, string name = "")
+        {
+            if (value is not null)
+            {
+                builder.Add(new BytesTag([.. value], name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddIntegers(int[]? value, string name = "")
+        {
+            if (value is not null)
+            {
+                builder.Add(new IntegersTag([.. value], name));
+            }
+
+            return builder;
+        }
+
+        public CompoundTagBuilder AddLongs(long[]? value, string name = "")
+        {
+            if (value is not null)
+            {
+                builder.Add(new LongsTag([.. value], name));
+            }
+
+            return builder;
+        }
+    }
+}
+
+public static class CompoundTagBuilderListExtensions
+{
+    extension(CompoundTagBuilder builder)
+    {
+        public CompoundTagBuilder AddByteList(ReadOnlySpan<byte?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddByteList(ReadOnlySpan<byte> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddShortList(ReadOnlySpan<short?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddShortList(ReadOnlySpan<short> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddLongList(ReadOnlySpan<long?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddLongList(ReadOnlySpan<long> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddFloatList(ReadOnlySpan<float?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddFloatList(ReadOnlySpan<float> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddStringList(ReadOnlySpan<string?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<StringTag>.Create(name).AddStringRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddCompoundList(ReadOnlySpan<CompoundTag?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<CompoundTag>.Create(name).AddCompoundRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : ITag
+        {
+            builder.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddBytesList(ReadOnlySpan<byte[]?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<BytesTag>.Create(name).AddBytesRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddIntegersList(ReadOnlySpan<int[]?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<IntegersTag>.Create(name).AddIntegersRange(values).Build());
+            return builder;
+        }
+
+        public CompoundTagBuilder AddLongsList(ReadOnlySpan<long[]?> values, string name = "")
+        {
+            builder.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
+            return builder;
+        }
     }
 }

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -242,9 +242,9 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
-    public CompoundTagBuilder AddListList(ReadOnlySpan<ListTag?> values, string name = "")
+    public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : Tag
     {
-        tags.Add(ListTagBuilder<ListTag>.Create(name).AddListRange(values).Build());
+        tags.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
         return this;
     }
 

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -95,7 +95,7 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
-    public CompoundTagBuilder AddList(ListTag? value, string name = "")
+    public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : Tag
     {
         if (value is not null)
         {

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -2,10 +2,10 @@ namespace Raspite.Tags.Building;
 
 public sealed class CompoundTagBuilder
 {
-    private readonly List<Tag> tags;
+    private readonly List<ITag> tags;
     private readonly string parentName;
 
-    internal CompoundTagBuilder(List<Tag> initialTags, string name)
+    internal CompoundTagBuilder(List<ITag> initialTags, string name)
     {
         tags = initialTags;
         parentName = name;
@@ -16,7 +16,7 @@ public sealed class CompoundTagBuilder
         return new CompoundTagBuilder([], name);
     }
 
-    internal void Add(Tag tag)
+    internal void Add(ITag tag)
     {
         tags.Add(tag);
     }
@@ -27,7 +27,7 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
-    public CompoundTagBuilder RemoveAll(Predicate<Tag> predicate)
+    public CompoundTagBuilder RemoveAll(Predicate<ITag> predicate)
     {
         tags.RemoveAll(predicate);
         return this;

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -96,7 +96,7 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
-    public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : Tag
+    public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : ITag
     {
         if (value is not null)
         {
@@ -242,7 +242,7 @@ public sealed class CompoundTagBuilder
         return this;
     }
 
-    public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : Tag
+    public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : ITag
     {
         tags.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
         return this;

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -1,6 +1,6 @@
 namespace Raspite.Tags.Building;
 
-public sealed class ListTagBuilder<TTag> where TTag : Tag
+public sealed class ListTagBuilder<TTag> where TTag : ITag
 {
     private readonly List<TTag> tags;
     private readonly string parentName;
@@ -131,7 +131,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : Tag
+    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : ITag
     {
         if (value is not null)
         {
@@ -334,7 +334,7 @@ public static class ListTagBuilderRangeExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : Tag
+    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : ITag
     {
         foreach (ListTag<TTag>? value in range)
         {

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -21,9 +21,9 @@ public sealed class ListTagBuilder<TTag> where TTag : ITag
         tags.Add(tag);
     }
 
-    public ListTagBuilder<TTag> Remove(string name)
+    public ListTagBuilder<TTag> RemoveAt(int index)
     {
-        tags.RemoveAll(tag => tag.Name == name);
+        tags.RemoveAt(index);
         return this;
     }
 

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -33,9 +33,9 @@ public sealed class ListTagBuilder<TTag> where TTag : Tag
         return this;
     }
 
-    public ListTag Build()
+    public ListTag<TTag> Build()
     {
-        return new ListTag([.. tags], parentName);
+        return new ListTag<TTag>([.. tags], parentName);
     }
 }
 
@@ -131,7 +131,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag> AddList(this ListTagBuilder<ListTag> builder, ListTag? value)
+    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : Tag
     {
         if (value is not null)
         {
@@ -334,9 +334,9 @@ public static class ListTagBuilderRangeExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag> AddListRange(this ListTagBuilder<ListTag> builder, params ReadOnlySpan<ListTag?> range)
+    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : Tag
     {
-        foreach (ListTag? value in range)
+        foreach (ListTag<TTag>? value in range)
         {
             builder.AddList(value);
         }

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -16,7 +16,7 @@ public sealed class ListTagBuilder<TTag> where TTag : ITag
         return new ListTagBuilder<TTag>([], name);
     }
 
-    internal void Add(TTag tag)
+    public void Add(TTag tag)
     {
         tags.Add(tag);
     }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -22,79 +22,6 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }
 
-    public byte? GetByte(string name)
-    {
-        return (cache[name] as ByteTag)?.Value; 
-    }
-
-    public bool? GetBoolean(string name)
-    {
-        var value = (cache[name] as ByteTag)?.Value;
-        return value is null ? null : value != 0; 
-    }
-
-    public short? GetShort(string name)
-    {
-        return (cache[name] as ShortTag)?.Value; 
-    }
-
-    public int? GetInteger(string name)
-    {
-        return (cache[name] as IntegerTag)?.Value; 
-    }
-
-    public long? GetLong(string name)
-    {
-        return (cache[name] as LongTag)?.Value; 
-    }
-
-    public float? GetFloat(string name)
-    {
-        return (cache[name] as FloatTag)?.Value; 
-    }
-
-    public double? GetDouble(string name)
-    {
-        return (cache[name] as DoubleTag)?.Value; 
-    }
-
-    public string? GetString(string name)
-    {
-        return (cache[name] as StringTag)?.Value; 
-    }
-
-    public ListTag<TTag>? GetList<TTag>(string name) where TTag : ITag
-    {
-        var tag = cache[name];
-
-        return tag switch
-        {
-            ListTag<TTag> typedListTag => typedListTag,
-            ListTag<EndTag> emptyListTag => new ListTag<TTag>([], emptyListTag.Name),
-            _ => null,
-        };
-    }
-
-    public CompoundTag? GetCompound(string name)
-    {
-        return cache[name] as CompoundTag; 
-    }
-
-    public ImmutableArray<byte>? GetBytes(string name)
-    {
-        return (cache[name] as BytesTag)?.Value; 
-    }
-
-    public ImmutableArray<int>? GetIntegers(string name)
-    {
-        return (cache[name] as IntegersTag)?.Value; 
-    }
-
-    public ImmutableArray<long>? GetLongs(string name)
-    {
-        return (cache[name] as LongsTag)?.Value; 
-    }
-
     public bool ContainsKey(string name)
     {
         return cache.ContainsKey(name);
@@ -113,5 +40,84 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
     public CompoundTagBuilder ToBuilder(string? name = null)
     {
         return new CompoundTagBuilder([.. Value], name ?? Name);
+    }
+}
+
+public static class CompoundTagExtensions
+{
+    extension(CompoundTag compoundTag)
+    {
+        public byte? GetByte(string name)
+        {
+            return (compoundTag[name] as ByteTag)?.Value; 
+        }
+
+        public bool? GetBoolean(string name)
+        {
+            var value = (compoundTag[name] as ByteTag)?.Value;
+            return value is null ? null : value != 0; 
+        }
+
+        public short? GetShort(string name)
+        {
+            return (compoundTag[name] as ShortTag)?.Value; 
+        }
+
+        public int? GetInteger(string name)
+        {
+            return (compoundTag[name] as IntegerTag)?.Value; 
+        }
+
+        public long? GetLong(string name)
+        {
+            return (compoundTag[name] as LongTag)?.Value; 
+        }
+
+        public float? GetFloat(string name)
+        {
+            return (compoundTag[name] as FloatTag)?.Value; 
+        }
+
+        public double? GetDouble(string name)
+        {
+            return (compoundTag[name] as DoubleTag)?.Value; 
+        }
+
+        public string? GetString(string name)
+        {
+            return (compoundTag[name] as StringTag)?.Value; 
+        }
+
+        public ListTag<TTag>? GetList<TTag>(string name) where TTag : ITag
+        {
+            var tag = compoundTag[name];
+
+            return tag switch
+            {
+                ListTag<TTag> typedListTag => typedListTag,
+                ListTag<EndTag> emptyListTag => new ListTag<TTag>([], emptyListTag.Name),
+                _ => null,
+            };
+        }
+
+        public CompoundTag? GetCompound(string name)
+        {
+            return compoundTag[name] as CompoundTag; 
+        }
+
+        public ImmutableArray<byte>? GetBytes(string name)
+        {
+            return (compoundTag[name] as BytesTag)?.Value; 
+        }
+
+        public ImmutableArray<int>? GetIntegers(string name)
+        {
+            return (compoundTag[name] as IntegersTag)?.Value; 
+        }
+
+        public ImmutableArray<long>? GetLongs(string name)
+        {
+            return (compoundTag[name] as LongsTag)?.Value; 
+        }
     }
 }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -63,7 +63,7 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
         return (cache[name] as StringTag)?.Value; 
     }
 
-    public ListTag<TTag>? GetList<TTag>(string name) where TTag : Tag
+    public ListTag<TTag>? GetList<TTag>(string name) where TTag : ITag
     {
         var tag = cache[name];
 

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Frozen;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 
 using Raspite.Tags.Building;
 
@@ -23,53 +22,77 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }
 
-    public TTag Get<TTag>(string name) where TTag : Tag
+    public byte? GetByte(string name)
     {
-        return (TTag) cache[name];
+        return (cache[name] as ByteTag)?.Value; 
     }
 
-    public T GetValue<T>(string name)
+    public bool? GetBoolean(string name)
     {
-        return ((Tag<T>) cache[name]).Value;
+        var value = (cache[name] as ByteTag)?.Value;
+        return value is null ? null : value != 0; 
     }
 
-    public TTag? GetOrDefault<TTag>(string name) where TTag : Tag
+    public short? GetShort(string name)
     {
-        return cache.GetValueOrDefault(name) as TTag;
+        return (cache[name] as ShortTag)?.Value; 
     }
 
-    public T? GetValueOrDefault<T>(string name)
+    public int? GetInteger(string name)
     {
-        if (cache.GetValueOrDefault(name) is Tag<T> tag)
+        return (cache[name] as IntegerTag)?.Value; 
+    }
+
+    public long? GetLong(string name)
+    {
+        return (cache[name] as LongTag)?.Value; 
+    }
+
+    public float? GetFloat(string name)
+    {
+        return (cache[name] as FloatTag)?.Value; 
+    }
+
+    public double? GetDouble(string name)
+    {
+        return (cache[name] as DoubleTag)?.Value; 
+    }
+
+    public string? GetString(string name)
+    {
+        return (cache[name] as StringTag)?.Value; 
+    }
+
+    public ListTag<TTag>? GetList<TTag>(string name) where TTag : Tag
+    {
+        var tag = cache[name];
+
+        return tag switch
         {
-            return tag.Value;
-        }
-
-        return default;
+            ListTag<TTag> typedListTag => typedListTag,
+            IListTag { Length: 0 } listTag => new ListTag<TTag>([], listTag.Name),
+            _ => null,
+        };
     }
 
-    public bool TryGet<TTag>(string name, [NotNullWhen(true)] out TTag? tag) where TTag : Tag
+    public CompoundTag? GetCompound(string name)
     {
-        if (cache.TryGetValue(name, out var rawTag) && rawTag is TTag typedTag)
-        {
-            tag = typedTag;
-            return true;
-        }
-
-        tag = null;
-        return false;
+        return cache[name] as CompoundTag; 
     }
 
-    public bool TryGetValue<T>(string name, [NotNullWhen(true)] out T? value)
+    public ImmutableArray<byte>? GetBytes(string name)
     {
-        if (cache.TryGetValue(name, out var rawTag) && rawTag is Tag<T> typedTag)
-        {
-            value = typedTag.Value;
-            return value is not null;
-        }
+        return (cache[name] as BytesTag)?.Value; 
+    }
 
-        value = default;
-        return false;
+    public ImmutableArray<int>? GetIntegers(string name)
+    {
+        return (cache[name] as IntegersTag)?.Value; 
+    }
+
+    public ImmutableArray<long>? GetLongs(string name)
+    {
+        return (cache[name] as LongsTag)?.Value; 
     }
 
     public bool ContainsKey(string name)

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -70,7 +70,7 @@ public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
         return tag switch
         {
             ListTag<TTag> typedListTag => typedListTag,
-            IListTag { Length: 0 } listTag => new ListTag<TTag>([], listTag.Name),
+            ListTag<EndTag> emptyListTag => new ListTag<TTag>([], emptyListTag.Name),
             _ => null,
         };
     }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -5,19 +5,19 @@ using Raspite.Tags.Building;
 
 namespace Raspite.Tags;
 
-public sealed class CompoundTag : Tag<ImmutableArray<Tag>>
+public sealed class CompoundTag : Tag<ImmutableArray<ITag>>
 {
     public override byte Identifier => Compound;
 
-    public Tag this[string name] => cache[name];
+    public ITag this[string name] => cache[name];
 
     public int Length => Value.Length;
 
     public ImmutableArray<string> Keys => cache.Keys;
 
-    private readonly FrozenDictionary<string, Tag> cache;
+    private readonly FrozenDictionary<string, ITag> cache;
 
-    public CompoundTag(ImmutableArray<Tag> value, string name = "") : base(value, name)
+    public CompoundTag(ImmutableArray<ITag> value, string name = "") : base(value, name)
     {
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -8,7 +8,7 @@ public interface IListTag : ITag
 {
     int Length { get; }
 
-    ImmutableArray<Tag> Elements { get; }
+    ImmutableArray<Tag> RawTags { get; }
 }
 
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
@@ -19,7 +19,7 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
 
     public int Length { get; } = value.Length;
 
-    public ImmutableArray<Tag> Elements { get; } = value.CastArray<Tag>();
+    public ImmutableArray<Tag> RawTags { get; } = value.CastArray<Tag>();
 
     /// <summary>
     /// Converts this tag to a builder containing all the values this tag contained.

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -40,3 +40,61 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
         return new ListTagBuilder<TTag>([.. Value], name ?? Name);
     }
 }
+
+public static class ListTagExtensions
+{
+    public static byte GetByte(this ListTag<ByteTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static bool GetBoolean(this ListTag<ByteTag> listTag, int index)
+    {
+        return listTag[index].Value != 0; 
+    }
+
+    public static short GetShort(this ListTag<ShortTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static int GetInteger(this ListTag<IntegerTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static long GetLong(this ListTag<LongTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static float GetFloat(this ListTag<FloatTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static double GetDouble(this ListTag<DoubleTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static string GetString(this ListTag<StringTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static ImmutableArray<byte> GetBytes(this ListTag<BytesTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static ImmutableArray<int> GetIntegers(this ListTag<IntegersTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+
+    public static ImmutableArray<long> GetLongs(this ListTag<LongsTag> listTag, int index)
+    {
+        return listTag[index].Value; 
+    }
+}

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -6,8 +6,6 @@ namespace Raspite.Tags;
 
 public interface IListTag : ITag
 {
-    byte ElementIdentifier { get; }
-
     int Length { get; }
 
     ImmutableArray<Tag> Elements { get; }
@@ -16,8 +14,6 @@ public interface IListTag : ITag
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
 {
     public override byte Identifier => List;
-
-    public byte ElementIdentifier { get; } = value.Length > 0 ? value[0].Identifier : End;
 
     public TTag this[int index] => Value[index];
 

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -2,11 +2,28 @@
 
 namespace Raspite.Tags;
 
-public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name) where TTag : Tag
+public interface IListTag
+{
+    string Name { get; }
+
+    byte Identifier { get; }
+
+    byte ElementIdentifier { get; }
+
+    int Length { get; }
+
+    ImmutableArray<Tag> Elements { get; }
+}
+
+public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : Tag
 {
     public override byte Identifier => List;
 
+    public byte ElementIdentifier { get; } = value.Length > 0 ? value[0].Identifier : End;
+
     public TTag this[int index] => Value[index];
 
-    public int Length => Value.Length;
+    public int Length { get; } = value.Length;
+
+    public ImmutableArray<Tag> Elements { get; } = value.CastArray<Tag>();
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Immutable;
 
+using Raspite.Tags.Building;
+
 namespace Raspite.Tags;
 
 public interface IListTag
@@ -26,4 +28,19 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
     public int Length { get; } = value.Length;
 
     public ImmutableArray<Tag> Elements { get; } = value.CastArray<Tag>();
+
+    /// <summary>
+    /// Converts this tag to a builder containing all the values this tag contained.
+    /// It is the inverse operation of <code>ListTagBuilder{TTag}.Build()</code>
+    /// </summary>
+    /// <param name="name">
+    /// The name of the tag about to be built.
+    /// Can be used for renaming it.
+    /// <code>null</code> to leave the name as it was.
+    /// </param>
+    /// <returns></returns>
+    public ListTagBuilder<TTag> ToBuilder(string? name = null)
+    {
+        return new ListTagBuilder<TTag>([.. Value], name ?? Name);
+    }
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -4,12 +4,8 @@ using Raspite.Tags.Building;
 
 namespace Raspite.Tags;
 
-public interface IListTag
+public interface IListTag : ITag
 {
-    string Name { get; }
-
-    byte Identifier { get; }
-
     byte ElementIdentifier { get; }
 
     int Length { get; }
@@ -17,13 +13,13 @@ public interface IListTag
     ImmutableArray<Tag> Elements { get; }
 }
 
-public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : Tag
+public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
 {
     public override byte Identifier => List;
 
     public byte ElementIdentifier { get; } = value.Length > 0 ? value[0].Identifier : End;
 
-    public Tag this[int index] => Value[index];
+    public TTag this[int index] => Value[index];
 
     public int Length { get; } = value.Length;
 

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -8,7 +8,7 @@ public interface IListTag : ITag
 {
     int Length { get; }
 
-    ImmutableArray<Tag> RawTags { get; }
+    ImmutableArray<ITag> RawTags { get; }
 }
 
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
@@ -19,7 +19,7 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
 
     public int Length { get; } = value.Length;
 
-    public ImmutableArray<Tag> RawTags { get; } = value.CastArray<Tag>();
+    public ImmutableArray<ITag> RawTags { get; } = value.CastArray<ITag>();
 
     /// <summary>
     /// Converts this tag to a builder containing all the values this tag contained.

--- a/Raspite/Tags/Tag.cs
+++ b/Raspite/Tags/Tag.cs
@@ -2,8 +2,15 @@
 
 namespace Raspite.Tags;
 
+public interface ITag
+{
+    byte Identifier { get; }
+
+    string Name { get; }
+}
+
 [DebuggerDisplay("{Name}")]
-public abstract class Tag(string name = "")
+public abstract class Tag(string name = "") : ITag
 {
     public abstract byte Identifier { get; }
 


### PR DESCRIPTION
Fixes #27
Fixes #28

This PR relies on changes made in #31, so it would probably make sense to get that merged first.

It should be noted that none of this new generic reading and writing functionality has been tested yet, although quite well thought through.