### PR TITLE
Refactor generics + Improve ListTag API

### DIFF
--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -72,7 +72,7 @@ public static class TagSerializer
 
     private static bool TryInstantiate(ref TagReader reader, out ITag tag, byte parent, int maximumDepth, int maximumChildren)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumDepth);
 
         tag = EndTag.Instance;
 
@@ -232,7 +232,7 @@ public static class TagSerializer
 
     private static void Write(ref TagWriter writer, ITag tag, int maximumDepth, int maximumChildren)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDepth, 0);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumDepth);
 
         switch (tag)
         {

--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -13,13 +13,13 @@ public static class TagSerializer
     /// Attempts to parse the <see cref="ReadOnlySpan{T}"/> as a <see cref="TTag"/>.
     /// </summary>
     /// <param name="buffer">The <see cref="ReadOnlySpan{T}"/> to parse.</param>
-    /// <param name="tag">The parsed <see cref="ITag"/>.</param>
+    /// <param name="tag">The parsed <see cref="TTag"/>.</param>
     /// <param name="options">The <see cref="TagSerializerOptions"/> to use.</param>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
     /// <typeparam name="TTag">The expected <see cref="TTag"/> type.</typeparam>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
     /// <exception cref="ArgumentException">The expected <see cref="TTag"/> was incorrect.</exception>
-    public static bool TryParse<TTag>(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out TTag? tag, TagSerializerOptions? options = null) where TTag : Tag
+    public static bool TryParse<TTag>(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out TTag? tag, TagSerializerOptions? options = null) where TTag : class, ITag
     {
         if (!TryParse(buffer, out var rawTag, options))
         {
@@ -201,7 +201,7 @@ public static class TagSerializer
         }
     }
     
-    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out ITag tag) where TTag : ITag
+    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out ITag tag) where TTag : class, ITag
     {
         var items = ArrayPool<TTag>.Shared.Rent(length);
 

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -123,7 +123,7 @@ public static class CompoundTagBuilderExtensions
             return builder;
         }
 
-        public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : ITag
+        public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : class, ITag
         {
             if (value is not null)
             {
@@ -275,7 +275,7 @@ public static class CompoundTagBuilderListExtensions
             return builder;
         }
 
-        public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : ITag
+        public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : class, ITag
         {
             builder.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
             return builder;

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -1,6 +1,6 @@
 namespace Raspite.Tags.Building;
 
-public sealed class ListTagBuilder<TTag> where TTag : ITag
+public sealed class ListTagBuilder<TTag> where TTag : class, ITag
 {
     private readonly List<TTag> tags;
     private readonly string parentName;
@@ -131,7 +131,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : ITag
+    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : class, ITag
     {
         if (value is not null)
         {
@@ -334,7 +334,7 @@ public static class ListTagBuilderRangeExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : ITag
+    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : class, ITag
     {
         foreach (ListTag<TTag>? value in range)
         {

--- a/Raspite/Tags/BytesTag.cs
+++ b/Raspite/Tags/BytesTag.cs
@@ -6,8 +6,8 @@ public sealed class BytesTag(ImmutableArray<byte> value, string name = "") : Tag
 {
     public override byte Identifier => Bytes;
 
-    public static BytesTag Create(IEnumerable<byte> tags, string name = "")
+    public static BytesTag Create(IEnumerable<byte> bytes, string name = "")
     {
-        return new BytesTag([.. tags], name);
+        return new BytesTag([.. bytes], name);
     }
 }

--- a/Raspite/Tags/BytesTag.cs
+++ b/Raspite/Tags/BytesTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class BytesTag(ImmutableArray<byte> value, string name = "") : Tag<ImmutableArray<byte>>(value, name)
 {
     public override byte Identifier => Bytes;
+
+    public static BytesTag Create(IEnumerable<byte> tags, string name = "")
+    {
+        return new BytesTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -88,7 +88,7 @@ public static class CompoundTagExtensions
             return (compoundTag[name] as StringTag)?.Value; 
         }
 
-        public ListTag<TTag>? GetList<TTag>(string name) where TTag : ITag
+        public ListTag<TTag>? GetList<TTag>(string name) where TTag : class, ITag
         {
             var tag = compoundTag[name];
 

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -22,6 +22,11 @@ public sealed class CompoundTag : Tag<ImmutableArray<ITag>>
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }
 
+    public static CompoundTag Create(IEnumerable<ITag> tags, string name = "")
+    {
+        return new CompoundTag([.. tags], name);
+    }
+
     public bool ContainsKey(string name)
     {
         return cache.ContainsKey(name);

--- a/Raspite/Tags/IntegersTag.cs
+++ b/Raspite/Tags/IntegersTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class IntegersTag(ImmutableArray<int> value, string name = "") : Tag<ImmutableArray<int>>(value, name)
 {
     public override byte Identifier => Integers;
+
+    public static IntegersTag Create(IEnumerable<int> tags, string name = "")
+    {
+        return new IntegersTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/IntegersTag.cs
+++ b/Raspite/Tags/IntegersTag.cs
@@ -6,8 +6,8 @@ public sealed class IntegersTag(ImmutableArray<int> value, string name = "") : T
 {
     public override byte Identifier => Integers;
 
-    public static IntegersTag Create(IEnumerable<int> tags, string name = "")
+    public static IntegersTag Create(IEnumerable<int> ints, string name = "")
     {
-        return new IntegersTag([.. tags], name);
+        return new IntegersTag([.. ints], name);
     }
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -13,16 +13,25 @@ public interface IListTag : ITag
 
 public static class ListTag
 {
-    public static IListTag Create(ITag[] tags, string name = "")
+    public static IListTag Create(IReadOnlyList<ITag> tags, string name = "", bool validate = true)
     {
-        if (tags.Length == 0)
+        if (tags.Count == 0)
         {
             return new ListTag<EndTag>([], name);
         }
 
-        var identifier = tags.Select(tag => tag.Identifier)
-            .Distinct()
-            .Single();
+        var identifier = tags[0].Identifier;
+
+        if (validate)
+        {
+            for (int i = 1; i < tags.Count; i++)
+            {
+                if (identifier != tags[i].Identifier)
+                {
+                    throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
+                }
+            }
+        }
 
         return identifier switch
         {

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -50,6 +50,11 @@ public static class ListTag
             _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
         };
     }
+
+    public static ListTag<TTag> Create<TTag>(IEnumerable<TTag> tags, string name = "") where TTag : class, ITag
+    {
+        return new ListTag<TTag>([.. tags], name);
+    }
 }
 
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -13,24 +13,18 @@ public interface IListTag : ITag
 
 public static class ListTag
 {
-    public static IListTag Create(IReadOnlyList<ITag> tags, string name = "", bool validate = true)
+    public static IListTag Create(IReadOnlyCollection<ITag> tags, string name = "", bool validate = true)
     {
         if (tags.Count == 0)
         {
             return new ListTag<EndTag>([], name);
         }
 
-        var identifier = tags[0].Identifier;
+        var identifier = tags.First().Identifier;
 
-        if (validate)
+        if (validate && tags.Any(tag => tag.Identifier != identifier))
         {
-            for (int i = 1; i < tags.Count; i++)
-            {
-                if (identifier != tags[i].Identifier)
-                {
-                    throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
-                }
-            }
+            throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
         }
 
         return identifier switch

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -35,18 +35,18 @@ public static class ListTag
 
         return identifier switch
         {
-            Tag.Byte => new ListTag<ByteTag>([.. tags.Cast<ByteTag>()], name),
-            Tag.Short => new ListTag<ShortTag>([.. tags.Cast<ShortTag>()], name),
-            Tag.Integer => new ListTag<IntegerTag>([.. tags.Cast<IntegerTag>()], name),
-            Tag.Long => new ListTag<LongTag>([.. tags.Cast<LongTag>()], name),
-            Tag.Float => new ListTag<FloatTag>([.. tags.Cast<FloatTag>()], name),
-            Tag.Double => new ListTag<DoubleTag>([.. tags.Cast<DoubleTag>()], name),
-            Tag.Bytes => new ListTag<BytesTag>([.. tags.Cast<BytesTag>()], name),
-            Tag.String => new ListTag<StringTag>([.. tags.Cast<StringTag>()], name),
-            Tag.List => new ListTag<IListTag>([.. tags.Cast<IListTag>()], name),
-            Tag.Compound => new ListTag<CompoundTag>([.. tags.Cast<CompoundTag>()], name),
-            Tag.Integers => new ListTag<IntegersTag>([.. tags.Cast<IntegersTag>()], name),
-            Tag.Longs => new ListTag<LongsTag>([.. tags.Cast<LongsTag>()], name),
+            Tag.Byte => Create(tags.Cast<ByteTag>(), name),
+            Tag.Short => Create(tags.Cast<ShortTag>(), name),
+            Tag.Integer => Create(tags.Cast<IntegerTag>(), name),
+            Tag.Long => Create(tags.Cast<LongTag>(), name),
+            Tag.Float => Create(tags.Cast<FloatTag>(), name),
+            Tag.Double => Create(tags.Cast<DoubleTag>(), name),
+            Tag.Bytes => Create(tags.Cast<BytesTag>(), name),
+            Tag.String => Create(tags.Cast<StringTag>(), name),
+            Tag.List => Create(tags.Cast<IListTag>(), name),
+            Tag.Compound => Create(tags.Cast<CompoundTag>(), name),
+            Tag.Integers => Create(tags.Cast<IntegersTag>(), name),
+            Tag.Longs => Create(tags.Cast<LongsTag>(), name),
             _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
         };
     }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -11,7 +11,7 @@ public interface IListTag : ITag
     ImmutableArray<ITag> RawTags { get; }
 }
 
-public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
+public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag
 {
     public override byte Identifier => List;
 
@@ -19,7 +19,7 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
 
     public int Length { get; } = value.Length;
 
-    public ImmutableArray<ITag> RawTags { get; } = value.CastArray<ITag>();
+    public ImmutableArray<ITag> RawTags { get; } = ImmutableArray<ITag>.CastUp(value);
 
     /// <summary>
     /// Converts this tag to a builder containing all the values this tag contained.

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -11,6 +11,38 @@ public interface IListTag : ITag
     ImmutableArray<ITag> RawTags { get; }
 }
 
+public static class ListTag
+{
+    public static IListTag Create(ITag[] tags, string name = "")
+    {
+        if (tags.Length == 0)
+        {
+            return new ListTag<EndTag>([], name);
+        }
+
+        var identifier = tags.Select(tag => tag.Identifier)
+            .Distinct()
+            .Single();
+
+        return identifier switch
+        {
+            Tag.Byte => new ListTag<ByteTag>([.. tags.Cast<ByteTag>()], name),
+            Tag.Short => new ListTag<ShortTag>([.. tags.Cast<ShortTag>()], name),
+            Tag.Integer => new ListTag<IntegerTag>([.. tags.Cast<IntegerTag>()], name),
+            Tag.Long => new ListTag<LongTag>([.. tags.Cast<LongTag>()], name),
+            Tag.Float => new ListTag<FloatTag>([.. tags.Cast<FloatTag>()], name),
+            Tag.Double => new ListTag<DoubleTag>([.. tags.Cast<DoubleTag>()], name),
+            Tag.Bytes => new ListTag<BytesTag>([.. tags.Cast<BytesTag>()], name),
+            Tag.String => new ListTag<StringTag>([.. tags.Cast<StringTag>()], name),
+            Tag.List => new ListTag<IListTag>([.. tags.Cast<IListTag>()], name),
+            Tag.Compound => new ListTag<CompoundTag>([.. tags.Cast<CompoundTag>()], name),
+            Tag.Integers => new ListTag<IntegersTag>([.. tags.Cast<IntegersTag>()], name),
+            Tag.Longs => new ListTag<LongsTag>([.. tags.Cast<LongsTag>()], name),
+            _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
+        };
+    }
+}
+
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag
 {
     public override byte Identifier => List;

--- a/Raspite/Tags/LongsTag.cs
+++ b/Raspite/Tags/LongsTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class LongsTag(ImmutableArray<long> value, string name = "") : Tag<ImmutableArray<long>>(value, name)
 {
     public override byte Identifier => Longs;
+
+    public static LongsTag Create(IEnumerable<long> tags, string name = "")
+    {
+        return new LongsTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/LongsTag.cs
+++ b/Raspite/Tags/LongsTag.cs
@@ -6,8 +6,8 @@ public sealed class LongsTag(ImmutableArray<long> value, string name = "") : Tag
 {
     public override byte Identifier => Longs;
 
-    public static LongsTag Create(IEnumerable<long> tags, string name = "")
+    public static LongsTag Create(IEnumerable<long> longs, string name = "")
     {
-        return new LongsTag([.. tags], name);
+        return new LongsTag([.. longs], name);
     }
 }


### PR DESCRIPTION
- Use `CastUp` instead of `CastArray` to signal intent
- Use `class` constraint on `TTag` to make that possible, and also to be able to use `null` instead of `default`
- Add `Create` method to `ListTag` for dynamic creation

The last point is really useful for cases like these

```csharp
ListTag.Create([.. Extra.Select(extra => extra.ToNbt())
```

where `ToNbt` is defined as

```csharp
public abstract ITag ToNbt(string name = "");
```

meaning this code would get really complicated without such a helper method that automatically determines the common type of list elements. There are many more cases where this becomes necessary which is the reason I think this should be part of Raspite itself, rather than an expectation of each dev who uses this library to implement it themselves.

Let me know what you think and if anything can or should be improved! :)