### PR TITLE
Improve fluent API and optimize CompoundTag removal

### DIFF
--- a/Raspite/TagSerializer.cs
+++ b/Raspite/TagSerializer.cs
@@ -13,13 +13,13 @@ public static class TagSerializer
     /// Attempts to parse the <see cref="ReadOnlySpan{T}"/> as a <see cref="TTag"/>.
     /// </summary>
     /// <param name="buffer">The <see cref="ReadOnlySpan{T}"/> to parse.</param>
-    /// <param name="tag">The parsed <see cref="ITag"/>.</param>
+    /// <param name="tag">The parsed <see cref="TTag"/>.</param>
     /// <param name="options">The <see cref="TagSerializerOptions"/> to use.</param>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
     /// <typeparam name="TTag">The expected <see cref="TTag"/> type.</typeparam>
     /// <returns><c>true</c> if the <see cref="ReadOnlySpan{T}"/> was parsed successfully; otherwise, <c>false</c>.</returns>
     /// <exception cref="ArgumentException">The expected <see cref="TTag"/> was incorrect.</exception>
-    public static bool TryParse<TTag>(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out TTag? tag, TagSerializerOptions? options = null) where TTag : Tag
+    public static bool TryParse<TTag>(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out TTag? tag, TagSerializerOptions? options = null) where TTag : class, ITag
     {
         if (!TryParse(buffer, out var rawTag, options))
         {
@@ -201,7 +201,7 @@ public static class TagSerializer
         }
     }
     
-    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out ITag tag) where TTag : ITag
+    private static bool TryReadList<TTag>(ref TagReader reader, byte identifier, int length, string name, int maximumDepth, int maximumChildren, out ITag tag) where TTag : class, ITag
     {
         var items = ArrayPool<TTag>.Shared.Rent(length);
 

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -1,11 +1,15 @@
+using System.Collections.Frozen;
+
 namespace Raspite.Tags.Building;
 
 public sealed class CompoundTagBuilder
 {
-    private readonly List<ITag> tags;
+    public ITag this[string name] => tags[name];
+
+    private readonly Dictionary<string, ITag> tags;
     private readonly string parentName;
 
-    internal CompoundTagBuilder(List<ITag> initialTags, string name)
+    internal CompoundTagBuilder(Dictionary<string, ITag> initialTags, string name)
     {
         tags = initialTags;
         parentName = name;
@@ -16,26 +20,29 @@ public sealed class CompoundTagBuilder
         return new CompoundTagBuilder([], name);
     }
 
-    public void Add(ITag tag)
+    public CompoundTagBuilder Add(ITag tag, bool overwriteExisting = false)
     {
-        tags.Add(tag);
+        if (overwriteExisting)
+        {
+            tags[tag.Name] = tag;
+        }
+        else
+        {
+            tags.Add(tag.Name, tag);
+        }
+
+        return this;
     }
 
     public CompoundTagBuilder Remove(string name)
     {
-        tags.RemoveAll(tag => tag.Name == name);
-        return this;
-    }
-
-    public CompoundTagBuilder RemoveAll(Predicate<ITag> predicate)
-    {
-        tags.RemoveAll(predicate);
+        tags.Remove(name);
         return this;
     }
 
     public CompoundTag Build()
     {
-        return new CompoundTag([.. tags], parentName);
+        return new CompoundTag([.. tags.Values], tags.ToFrozenDictionary(), parentName);
     }
 }
 
@@ -45,132 +52,93 @@ public static class CompoundTagBuilderExtensions
     {
         public CompoundTagBuilder AddByte(byte? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new ByteTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new ByteTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddBoolean(bool? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new ByteTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new ByteTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddShort(short? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new ShortTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new ShortTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddInteger(int? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new IntegerTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new IntegerTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddLong(long? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new LongTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new LongTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddFloat(float? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new FloatTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new FloatTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddDouble(double? value, string name = "")
         {
-            if (value.HasValue)
-            {
-                builder.Add(new DoubleTag(value.Value, name));
-            }
-
-            return builder;
+            return value.HasValue
+                ? builder.Add(new DoubleTag(value.Value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddString(string? value, string name = "")
         {
-            if (value is not null)
-            {
-                builder.Add(new StringTag(value, name));
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(new StringTag(value, name))
+                : builder;
         }
 
         public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : class, ITag
         {
-            if (value is not null)
-            {
-                builder.Add(value);
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(value)
+                : builder;
         }
 
         public CompoundTagBuilder AddCompound(CompoundTag? value, string name = "")
         {
-            if (value is not null)
-            {
-                builder.Add(value);
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(value)
+                : builder;
         }
 
         public CompoundTagBuilder AddBytes(byte[]? value, string name = "")
         {
-            if (value is not null)
-            {
-                builder.Add(new BytesTag([.. value], name));
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(new BytesTag([.. value], name))
+                : builder;
         }
 
         public CompoundTagBuilder AddIntegers(int[]? value, string name = "")
         {
-            if (value is not null)
-            {
-                builder.Add(new IntegersTag([.. value], name));
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(new IntegersTag([.. value], name))
+                : builder;
         }
 
         public CompoundTagBuilder AddLongs(long[]? value, string name = "")
         {
-            if (value is not null)
-            {
-                builder.Add(new LongsTag([.. value], name));
-            }
-
-            return builder;
+            return value is not null
+                ? builder.Add(new LongsTag([.. value], name))
+                : builder;
         }
     }
 }
@@ -181,122 +149,102 @@ public static class CompoundTagBuilderListExtensions
     {
         public CompoundTagBuilder AddByteList(ReadOnlySpan<byte?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
         }
 
         public CompoundTagBuilder AddByteList(ReadOnlySpan<byte> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ByteTag>.Create(name).AddByteRange(values).Build());
         }
 
         public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
         }
 
         public CompoundTagBuilder AddBooleanList(ReadOnlySpan<bool> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ByteTag>.Create(name).AddBooleanRange(values).Build());
         }
 
         public CompoundTagBuilder AddShortList(ReadOnlySpan<short?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
         }
 
         public CompoundTagBuilder AddShortList(ReadOnlySpan<short> values, string name = "")
         {
-            builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ShortTag>.Create(name).AddShortRange(values).Build());
         }
 
         public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
         }
 
         public CompoundTagBuilder AddIntegerList(ReadOnlySpan<int> values, string name = "")
         {
-            builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<IntegerTag>.Create(name).AddIntegerRange(values).Build());
         }
 
         public CompoundTagBuilder AddLongList(ReadOnlySpan<long?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
         }
 
         public CompoundTagBuilder AddLongList(ReadOnlySpan<long> values, string name = "")
         {
-            builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<LongTag>.Create(name).AddLongRange(values).Build());
         }
 
         public CompoundTagBuilder AddFloatList(ReadOnlySpan<float?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
         }
 
         public CompoundTagBuilder AddFloatList(ReadOnlySpan<float> values, string name = "")
         {
-            builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<FloatTag>.Create(name).AddFloatRange(values).Build());
         }
 
         public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double> values, string name = "")
         {
-            builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
         }
 
         public CompoundTagBuilder AddDoubleList(ReadOnlySpan<double?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<DoubleTag>.Create(name).AddDoubleRange(values).Build());
         }
 
         public CompoundTagBuilder AddStringList(ReadOnlySpan<string?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<StringTag>.Create(name).AddStringRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<StringTag>.Create(name).AddStringRange(values).Build());
         }
 
         public CompoundTagBuilder AddCompoundList(ReadOnlySpan<CompoundTag?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<CompoundTag>.Create(name).AddCompoundRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<CompoundTag>.Create(name).AddCompoundRange(values).Build());
         }
 
         public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : class, ITag
         {
-            builder.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
         }
 
         public CompoundTagBuilder AddBytesList(ReadOnlySpan<byte[]?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<BytesTag>.Create(name).AddBytesRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<BytesTag>.Create(name).AddBytesRange(values).Build());
         }
 
         public CompoundTagBuilder AddIntegersList(ReadOnlySpan<int[]?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<IntegersTag>.Create(name).AddIntegersRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<IntegersTag>.Create(name).AddIntegersRange(values).Build());
         }
 
         public CompoundTagBuilder AddLongsList(ReadOnlySpan<long[]?> values, string name = "")
         {
-            builder.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
-            return builder;
+            return builder.Add(ListTagBuilder<LongsTag>.Create(name).AddLongsRange(values).Build());
         }
     }
 }

--- a/Raspite/Tags/Building/CompoundTagBuilder.cs
+++ b/Raspite/Tags/Building/CompoundTagBuilder.cs
@@ -123,7 +123,7 @@ public static class CompoundTagBuilderExtensions
             return builder;
         }
 
-        public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : ITag
+        public CompoundTagBuilder AddList<TTag>(ListTag<TTag>? value, string name = "") where TTag : class, ITag
         {
             if (value is not null)
             {
@@ -275,7 +275,7 @@ public static class CompoundTagBuilderListExtensions
             return builder;
         }
 
-        public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : ITag
+        public CompoundTagBuilder AddListList<TTag>(ReadOnlySpan<ListTag<TTag>?> values, string name = "") where TTag : class, ITag
         {
             builder.Add(ListTagBuilder<ListTag<TTag>>.Create(name).AddListRange(values).Build());
             return builder;

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -1,6 +1,6 @@
 namespace Raspite.Tags.Building;
 
-public sealed class ListTagBuilder<TTag> where TTag : ITag
+public sealed class ListTagBuilder<TTag> where TTag : class, ITag
 {
     private readonly List<TTag> tags;
     private readonly string parentName;
@@ -131,7 +131,7 @@ public static class ListTagBuilderExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : ITag
+    public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : class, ITag
     {
         if (value is not null)
         {
@@ -334,7 +334,7 @@ public static class ListTagBuilderRangeExtensions
         return builder;
     }
 
-    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : ITag
+    public static ListTagBuilder<ListTag<TTag>> AddListRange<TTag>(this ListTagBuilder<ListTag<TTag>> builder, params ReadOnlySpan<ListTag<TTag>?> range) where TTag : class, ITag
     {
         foreach (ListTag<TTag>? value in range)
         {

--- a/Raspite/Tags/Building/ListTagBuilder.cs
+++ b/Raspite/Tags/Building/ListTagBuilder.cs
@@ -16,9 +16,10 @@ public sealed class ListTagBuilder<TTag> where TTag : class, ITag
         return new ListTagBuilder<TTag>([], name);
     }
 
-    public void Add(TTag tag)
+    public ListTagBuilder<TTag> Add(TTag tag)
     {
         tags.Add(tag);
+        return this;
     }
 
     public ListTagBuilder<TTag> RemoveAt(int index)
@@ -43,132 +44,93 @@ public static class ListTagBuilderExtensions
 {
     public static ListTagBuilder<ByteTag> AddByte(this ListTagBuilder<ByteTag> builder, byte? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new ByteTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new ByteTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<ByteTag> AddBoolean(this ListTagBuilder<ByteTag> builder, bool? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new ByteTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new ByteTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<ShortTag> AddShort(this ListTagBuilder<ShortTag> builder, short? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new ShortTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new ShortTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<IntegerTag> AddInteger(this ListTagBuilder<IntegerTag> builder, int? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new IntegerTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new IntegerTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<LongTag> AddLong(this ListTagBuilder<LongTag> builder, long? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new LongTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new LongTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<FloatTag> AddFloat(this ListTagBuilder<FloatTag> builder, float? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new FloatTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new FloatTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<DoubleTag> AddDouble(this ListTagBuilder<DoubleTag> builder, double? value)
     {
-        if (value.HasValue)
-        {
-            builder.Add(new DoubleTag(value.Value));
-        }
-
-        return builder;
+        return value.HasValue
+            ? builder.Add(new DoubleTag(value.Value))
+            : builder;
     }
 
     public static ListTagBuilder<StringTag> AddString(this ListTagBuilder<StringTag> builder, string? value)
     {
-        if (value is not null)
-        {
-            builder.Add(new StringTag(value));
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(new StringTag(value))
+            : builder;
     }
 
     public static ListTagBuilder<CompoundTag> AddCompound(this ListTagBuilder<CompoundTag> builder, CompoundTag? value)
     {
-        if (value is not null)
-        {
-            builder.Add(value);
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(value)
+            : builder;
     }
 
     public static ListTagBuilder<ListTag<TTag>> AddList<TTag>(this ListTagBuilder<ListTag<TTag>> builder, ListTag<TTag>? value) where TTag : class, ITag
     {
-        if (value is not null)
-        {
-            builder.Add(value);
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(value)
+            : builder;
     }
 
     public static ListTagBuilder<BytesTag> AddBytes(this ListTagBuilder<BytesTag> builder, byte[]? value)
     {
-        if (value is not null)
-        {
-            builder.Add(new BytesTag([.. value]));
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(new BytesTag([.. value]))
+            : builder;
     }
 
     public static ListTagBuilder<IntegersTag> AddIntegers(this ListTagBuilder<IntegersTag> builder, int[]? value)
     {
-        if (value is not null)
-        {
-            builder.Add(new IntegersTag([.. value]));
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(new IntegersTag([.. value]))
+            : builder;
     }
 
     public static ListTagBuilder<LongsTag> AddLongs(this ListTagBuilder<LongsTag> builder, long[]? value)
     {
-        if (value is not null)
-        {
-            builder.Add(new LongsTag([.. value]));
-        }
-
-        return builder;
+        return value is not null
+            ? builder.Add(new LongsTag([.. value]))
+            : builder;
     }
 }
 

--- a/Raspite/Tags/BytesTag.cs
+++ b/Raspite/Tags/BytesTag.cs
@@ -6,8 +6,8 @@ public sealed class BytesTag(ImmutableArray<byte> value, string name = "") : Tag
 {
     public override byte Identifier => Bytes;
 
-    public static BytesTag Create(IEnumerable<byte> tags, string name = "")
+    public static BytesTag Create(IEnumerable<byte> bytes, string name = "")
     {
-        return new BytesTag([.. tags], name);
+        return new BytesTag([.. bytes], name);
     }
 }

--- a/Raspite/Tags/BytesTag.cs
+++ b/Raspite/Tags/BytesTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class BytesTag(ImmutableArray<byte> value, string name = "") : Tag<ImmutableArray<byte>>(value, name)
 {
     public override byte Identifier => Bytes;
+
+    public static BytesTag Create(IEnumerable<byte> tags, string name = "")
+    {
+        return new BytesTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -88,7 +88,7 @@ public static class CompoundTagExtensions
             return (compoundTag[name] as StringTag)?.Value; 
         }
 
-        public ListTag<TTag>? GetList<TTag>(string name) where TTag : ITag
+        public ListTag<TTag>? GetList<TTag>(string name) where TTag : class, ITag
         {
             var tag = compoundTag[name];
 

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -17,14 +17,19 @@ public sealed class CompoundTag : Tag<ImmutableArray<ITag>>
 
     private readonly FrozenDictionary<string, ITag> cache;
 
-    public CompoundTag(ImmutableArray<ITag> value, string name = "") : base(value, name)
+    public CompoundTag(ImmutableArray<ITag> value, string name = "") : this(value, value.ToFrozenDictionary(tag => tag.Name), name)
     {
-        cache = value.ToFrozenDictionary(tag => tag.Name);
+    }
+
+    internal CompoundTag(ImmutableArray<ITag> value, FrozenDictionary<string, ITag> cache, string name = "") : base(value, name)
+    {
+        this.cache = cache;
     }
 
     public static CompoundTag Create(IEnumerable<ITag> tags, string name = "")
     {
-        return new CompoundTag([.. tags], name);
+        ImmutableArray<ITag> immutableTags = [.. tags];
+        return new CompoundTag(immutableTags, immutableTags.ToFrozenDictionary(tag => tag.Name), name);
     }
 
     public bool ContainsKey(string name)
@@ -44,7 +49,7 @@ public sealed class CompoundTag : Tag<ImmutableArray<ITag>>
     /// <returns></returns>
     public CompoundTagBuilder ToBuilder(string? name = null)
     {
-        return new CompoundTagBuilder([.. Value], name ?? Name);
+        return new CompoundTagBuilder(cache.ToDictionary(), name ?? Name);
     }
 }
 

--- a/Raspite/Tags/CompoundTag.cs
+++ b/Raspite/Tags/CompoundTag.cs
@@ -22,6 +22,11 @@ public sealed class CompoundTag : Tag<ImmutableArray<ITag>>
         cache = value.ToFrozenDictionary(tag => tag.Name);
     }
 
+    public static CompoundTag Create(IEnumerable<ITag> tags, string name = "")
+    {
+        return new CompoundTag([.. tags], name);
+    }
+
     public bool ContainsKey(string name)
     {
         return cache.ContainsKey(name);

--- a/Raspite/Tags/IntegersTag.cs
+++ b/Raspite/Tags/IntegersTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class IntegersTag(ImmutableArray<int> value, string name = "") : Tag<ImmutableArray<int>>(value, name)
 {
     public override byte Identifier => Integers;
+
+    public static IntegersTag Create(IEnumerable<int> tags, string name = "")
+    {
+        return new IntegersTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/IntegersTag.cs
+++ b/Raspite/Tags/IntegersTag.cs
@@ -6,8 +6,8 @@ public sealed class IntegersTag(ImmutableArray<int> value, string name = "") : T
 {
     public override byte Identifier => Integers;
 
-    public static IntegersTag Create(IEnumerable<int> tags, string name = "")
+    public static IntegersTag Create(IEnumerable<int> ints, string name = "")
     {
-        return new IntegersTag([.. tags], name);
+        return new IntegersTag([.. ints], name);
     }
 }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -13,16 +13,25 @@ public interface IListTag : ITag
 
 public static class ListTag
 {
-    public static IListTag Create(ITag[] tags, string name = "")
+    public static IListTag Create(IReadOnlyList<ITag> tags, string name = "", bool validate = true)
     {
-        if (tags.Length == 0)
+        if (tags.Count == 0)
         {
             return new ListTag<EndTag>([], name);
         }
 
-        var identifier = tags.Select(tag => tag.Identifier)
-            .Distinct()
-            .Single();
+        var identifier = tags[0].Identifier;
+
+        if (validate)
+        {
+            for (int i = 1; i < tags.Count; i++)
+            {
+                if (identifier != tags[i].Identifier)
+                {
+                    throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
+                }
+            }
+        }
 
         return identifier switch
         {

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -50,6 +50,11 @@ public static class ListTag
             _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
         };
     }
+
+    public static ListTag<TTag> Create<TTag>(IEnumerable<TTag> tags, string name = "") where TTag : class, ITag
+    {
+        return new ListTag<TTag>([.. tags], name);
+    }
 }
 
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -13,24 +13,18 @@ public interface IListTag : ITag
 
 public static class ListTag
 {
-    public static IListTag Create(IReadOnlyList<ITag> tags, string name = "", bool validate = true)
+    public static IListTag Create(IReadOnlyCollection<ITag> tags, string name = "", bool validate = true)
     {
         if (tags.Count == 0)
         {
             return new ListTag<EndTag>([], name);
         }
 
-        var identifier = tags[0].Identifier;
+        var identifier = tags.First().Identifier;
 
-        if (validate)
+        if (validate && tags.Any(tag => tag.Identifier != identifier))
         {
-            for (int i = 1; i < tags.Count; i++)
-            {
-                if (identifier != tags[i].Identifier)
-                {
-                    throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
-                }
-            }
+            throw new ArgumentException("All tags in the list must be of the same type.", nameof(tags));
         }
 
         return identifier switch

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -35,18 +35,18 @@ public static class ListTag
 
         return identifier switch
         {
-            Tag.Byte => new ListTag<ByteTag>([.. tags.Cast<ByteTag>()], name),
-            Tag.Short => new ListTag<ShortTag>([.. tags.Cast<ShortTag>()], name),
-            Tag.Integer => new ListTag<IntegerTag>([.. tags.Cast<IntegerTag>()], name),
-            Tag.Long => new ListTag<LongTag>([.. tags.Cast<LongTag>()], name),
-            Tag.Float => new ListTag<FloatTag>([.. tags.Cast<FloatTag>()], name),
-            Tag.Double => new ListTag<DoubleTag>([.. tags.Cast<DoubleTag>()], name),
-            Tag.Bytes => new ListTag<BytesTag>([.. tags.Cast<BytesTag>()], name),
-            Tag.String => new ListTag<StringTag>([.. tags.Cast<StringTag>()], name),
-            Tag.List => new ListTag<IListTag>([.. tags.Cast<IListTag>()], name),
-            Tag.Compound => new ListTag<CompoundTag>([.. tags.Cast<CompoundTag>()], name),
-            Tag.Integers => new ListTag<IntegersTag>([.. tags.Cast<IntegersTag>()], name),
-            Tag.Longs => new ListTag<LongsTag>([.. tags.Cast<LongsTag>()], name),
+            Tag.Byte => Create(tags.Cast<ByteTag>(), name),
+            Tag.Short => Create(tags.Cast<ShortTag>(), name),
+            Tag.Integer => Create(tags.Cast<IntegerTag>(), name),
+            Tag.Long => Create(tags.Cast<LongTag>(), name),
+            Tag.Float => Create(tags.Cast<FloatTag>(), name),
+            Tag.Double => Create(tags.Cast<DoubleTag>(), name),
+            Tag.Bytes => Create(tags.Cast<BytesTag>(), name),
+            Tag.String => Create(tags.Cast<StringTag>(), name),
+            Tag.List => Create(tags.Cast<IListTag>(), name),
+            Tag.Compound => Create(tags.Cast<CompoundTag>(), name),
+            Tag.Integers => Create(tags.Cast<IntegersTag>(), name),
+            Tag.Longs => Create(tags.Cast<LongsTag>(), name),
             _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
         };
     }

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -11,7 +11,7 @@ public interface IListTag : ITag
     ImmutableArray<ITag> RawTags { get; }
 }
 
-public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : ITag
+public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag
 {
     public override byte Identifier => List;
 
@@ -19,7 +19,7 @@ public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") 
 
     public int Length { get; } = value.Length;
 
-    public ImmutableArray<ITag> RawTags { get; } = value.CastArray<ITag>();
+    public ImmutableArray<ITag> RawTags { get; } = ImmutableArray<ITag>.CastUp(value);
 
     /// <summary>
     /// Converts this tag to a builder containing all the values this tag contained.

--- a/Raspite/Tags/ListTag.cs
+++ b/Raspite/Tags/ListTag.cs
@@ -11,6 +11,38 @@ public interface IListTag : ITag
     ImmutableArray<ITag> RawTags { get; }
 }
 
+public static class ListTag
+{
+    public static IListTag Create(ITag[] tags, string name = "")
+    {
+        if (tags.Length == 0)
+        {
+            return new ListTag<EndTag>([], name);
+        }
+
+        var identifier = tags.Select(tag => tag.Identifier)
+            .Distinct()
+            .Single();
+
+        return identifier switch
+        {
+            Tag.Byte => new ListTag<ByteTag>([.. tags.Cast<ByteTag>()], name),
+            Tag.Short => new ListTag<ShortTag>([.. tags.Cast<ShortTag>()], name),
+            Tag.Integer => new ListTag<IntegerTag>([.. tags.Cast<IntegerTag>()], name),
+            Tag.Long => new ListTag<LongTag>([.. tags.Cast<LongTag>()], name),
+            Tag.Float => new ListTag<FloatTag>([.. tags.Cast<FloatTag>()], name),
+            Tag.Double => new ListTag<DoubleTag>([.. tags.Cast<DoubleTag>()], name),
+            Tag.Bytes => new ListTag<BytesTag>([.. tags.Cast<BytesTag>()], name),
+            Tag.String => new ListTag<StringTag>([.. tags.Cast<StringTag>()], name),
+            Tag.List => new ListTag<IListTag>([.. tags.Cast<IListTag>()], name),
+            Tag.Compound => new ListTag<CompoundTag>([.. tags.Cast<CompoundTag>()], name),
+            Tag.Integers => new ListTag<IntegersTag>([.. tags.Cast<IntegersTag>()], name),
+            Tag.Longs => new ListTag<LongsTag>([.. tags.Cast<LongsTag>()], name),
+            _ => throw new ArgumentOutOfRangeException(nameof(identifier), identifier, "Invalid tag identifier.")
+        };
+    }
+}
+
 public sealed class ListTag<TTag>(ImmutableArray<TTag> value, string name = "") : Tag<ImmutableArray<TTag>>(value, name), IListTag where TTag : class, ITag
 {
     public override byte Identifier => List;

--- a/Raspite/Tags/LongsTag.cs
+++ b/Raspite/Tags/LongsTag.cs
@@ -5,4 +5,9 @@ namespace Raspite.Tags;
 public sealed class LongsTag(ImmutableArray<long> value, string name = "") : Tag<ImmutableArray<long>>(value, name)
 {
     public override byte Identifier => Longs;
+
+    public static LongsTag Create(IEnumerable<long> tags, string name = "")
+    {
+        return new LongsTag([.. tags], name);
+    }
 }

--- a/Raspite/Tags/LongsTag.cs
+++ b/Raspite/Tags/LongsTag.cs
@@ -6,8 +6,8 @@ public sealed class LongsTag(ImmutableArray<long> value, string name = "") : Tag
 {
     public override byte Identifier => Longs;
 
-    public static LongsTag Create(IEnumerable<long> tags, string name = "")
+    public static LongsTag Create(IEnumerable<long> longs, string name = "")
     {
-        return new LongsTag([.. tags], name);
+        return new LongsTag([.. longs], name);
     }
 }


### PR DESCRIPTION
... by using a `Dictionary` in `CompoundTagBuilder` instead of a `List`.

These changes are based on changes made in #34 so it would make sense to merge that first.